### PR TITLE
Routing scopes

### DIFF
--- a/src/SimpleAjax/Resources/config/routing.yml
+++ b/src/SimpleAjax/Resources/config/routing.yml
@@ -2,8 +2,10 @@ richardhj.simple_ajax.default:
     path: /SimpleAjax.php
     defaults:
         _controller: richardhj.simple_ajax.controller
+        _scope: backend
 
 richardhj.simple_ajax.frontend:
     path: /SimpleAjaxFrontend.php
     defaults:
         _controller: richardhj.simple_ajax.controller
+        _scope: frontend


### PR DESCRIPTION
To be compatible with \Contao\CoreBundle\Framework\ContaoFramework's getMode() function we need to define the scopes (backend or frontend) for the new routes

Without these scopes the

$this->scopeMatcher->isBackendRequest($this->request)
and
$this->scopeMatcher->isFrontendRequest($this->request)

calls give back NULL and the TL_MODE constant (which is widely used) will be also NULL