### PR TITLE
allow symfony/http-foundation in Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "contao/core-bundle": "^4.4",
-    "symfony/http-foundation": "^3.3"
+    "symfony/http-foundation": "^3.3 || ^4.1"
   },
   "require-dev": {
     "phpcq/all-tasks": "~1.0"

--- a/src/SimpleAjax/Resources/config/services.yml
+++ b/src/SimpleAjax/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
           - "@event_dispatcher"
         calls:
           - [setContainer, ["@service_container"]]
+        tags: ['controller.service_arguments']
+        public: true
 
 parameters:
     simpleajax.entrypoint: "SimpleAjax.php"


### PR DESCRIPTION
Disclaimer: I haven't actually tested this change ;). I wanted to ask if there is a specific reason to only allow `symfony/http-foundation` for `^3.3` and not also for Symfony 4.

@fenepedia was trying to install it in Contao 4.6, but that is not possible without doing a full composer update - like so for instance:
```
composer require richardhj/contao-simple-ajax --no-update && composer update
```